### PR TITLE
format change for post_id database columns

### DIFF
--- a/core/helpers/class-database.php
+++ b/core/helpers/class-database.php
@@ -89,12 +89,12 @@ class Database
 
 		$sql = "
 		CREATE TABLE $table_name (
-		id mediumint(9) NOT NULL AUTO_INCREMENT,
+		id bigint(20) NOT NULL AUTO_INCREMENT,
 		time datetime DEFAULT '0000-00-00 00:00:00',
 		user varchar(55) DEFAULT NULL,
 		pro mediumint(1) DEFAULT NULL,
 		contra mediumint(1) DEFAULT NULL,
-		post_id mediumint(9) DEFAULT NULL,
+		post_id bigint(20) DEFAULT NULL,
 		PRIMARY KEY  (id)
 		) $charset_collate;
 		";
@@ -126,12 +126,12 @@ class Database
 
 		$sql = "
 		CREATE TABLE $table_name (
-		id mediumint(9) NOT NULL AUTO_INCREMENT, 
+		id bigint(20) NOT NULL AUTO_INCREMENT, 
 		time datetime DEFAULT '0000-00-00 00:00:00', 
 		user varchar(55) DEFAULT NULL, 
 		pro mediumint(1) DEFAULT NULL, 
 		contra mediumint(1) DEFAULT NULL, 
-		post_id mediumint(9) DEFAULT NULL, 
+		post_id bigint(20) DEFAULT NULL, 
 		message text DEFAULT NULL, 
 		fields text DEFAULT NULL, 
 		PRIMARY KEY  (id)


### PR DESCRIPTION
Hello @pixelbart 
Thanks for your plugin, however I have a database that has a lot of posts with IDs over 10 digits.
I noticed that the saving of the vote is inccorect (post_id) because your column structure is in "mediumint (9)" rather: "bigint (20)" like the WP tables.

I just made this change in your helper, but you need to create an update file for the existing tables