### PR TITLE
4.5.6

### DIFF
--- a/core/helpers/class-feedback.php
+++ b/core/helpers/class-feedback.php
@@ -237,7 +237,7 @@ class Feedback
     /**
      * Send feedback email.
      *
-     * @version 4.4.63
+     * @version 4.5.6
      *
      * @param array $feedback feedback data.
      *
@@ -547,7 +547,6 @@ class Feedback
         }
 
         if ('none' === $type) {
-
             if ('off' === $ap && 'off' === $ac && false === $show_feedback) {
                 $content = do_shortcode($options->get_option('helpful_after_fallback', '', 'kses'));
 
@@ -625,24 +624,36 @@ class Feedback
     /**
      * Get feedback email content.
      *
+     * @version 4.5.6
+     * 
      * @return string
      */
     public static function get_email_content()
     {
-        $file = plugins_url('templates/feedback-email.txt', HELPFUL_FILE);
-        $content = file_get_contents($file);
-        return apply_filters('helpful_pre_get_email_content', $content);
+        $file = plugins_url('templates/emails/feedback-email.txt', HELPFUL_FILE);
+        $file = apply_filters('helpful_pre_get_email_content_voter_file', $file);
+
+        $response = wp_remote_get($file);
+        $response = wp_remote_retrieve_body($response);
+
+        return apply_filters('helpful_pre_get_email_content_voter', $response);
     }
 
     /**
      * Get feedback email content for voters.
      *
+     * @version 4.5.6
+     * 
      * @return string
      */
     public static function get_email_content_voter()
     {
-        $file = plugins_url('templates/feedback-email-voter.txt', HELPFUL_FILE);
-        $content = file_get_contents($file);
-        return apply_filters('helpful_pre_get_email_content_voter', $content);
+        $file = plugins_url('templates/emails/feedback-email-voter.txt', HELPFUL_FILE);
+        $file = apply_filters('helpful_pre_get_email_content_voter_file', $file);
+
+        $response = wp_remote_get($file);
+        $response = wp_remote_retrieve_body($response);
+
+        return apply_filters('helpful_pre_get_email_content_voter', $response);
     }
 }

--- a/core/services/class-options.php
+++ b/core/services/class-options.php
@@ -2,7 +2,7 @@
 /**
  * @package Helpful
  * @subpackage Core\Services
- * @version 4.5.5
+ * @version 4.5.6
  * @since 4.4.47
  */
 namespace Helpful\Core\Services;

--- a/core/tabs/class-system.php
+++ b/core/tabs/class-system.php
@@ -2,7 +2,7 @@
 /**
  * @package Helpful
  * @subpackage Core\Tabs
- * @version 4.5.5
+ * @version 4.5.6
  * @since 4.3.0
  */
 namespace Helpful\Core\Tabs;
@@ -96,6 +96,10 @@ class System
                 'type' => 'string',
                 'sanitize_callback' => 'sanitize_text_field',
             ],
+            'helpful_classic_widgets' => [
+                'type' => 'string',
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
             'helpful_caching' => [
                 'type' => 'string',
                 'sanitize_callback' => 'sanitize_text_field',
@@ -125,6 +129,10 @@ class System
                 'sanitize_callback' => 'sanitize_text_field',
             ],
             'helpful_disable_feedback_nonce' => [
+                'type' => 'string',
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'helpful_log_mailer_errors' => [
                 'type' => 'string',
                 'sanitize_callback' => 'sanitize_text_field',
             ],

--- a/helpful.php
+++ b/helpful.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Helpful
  * Description: Add a fancy feedback form under your posts or post-types and ask your visitors a question. Give them the abbility to vote with yes or no.
- * Version: 4.5.5
+ * Version: 4.5.6
  * Author: Pixelbart
  * Author URI: https://pixelbart.de
  * Text Domain: helpful

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: helpful, poll, feedback, reviews, vote, review, voting
 Requires at least: 4.6
 Tested up to: 5.9
 Requires PHP: 5.6.20
-Stable tag: 4.5.5
+Stable tag: 4.5.6
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 

--- a/templates/emails/feedback-email-voter.txt
+++ b/templates/emails/feedback-email-voter.txt
@@ -1,0 +1,11 @@
+<p>Hello!</p>
+
+<p>You receive this e-mail because you gave feedback on {blog_name}. This data was submitted by you:</p>
+
+<p><strong>Name:</strong> {name}<br>
+<strong>Email:</strong> {email}<br>
+<strong>Message:</strong> {message}</p>
+
+<p>Thank you for your feedback!</p>
+
+<p>This message was sent by {blog_name}.</p>

--- a/templates/emails/feedback-email.txt
+++ b/templates/emails/feedback-email.txt
@@ -1,0 +1,10 @@
+<p>Hi!</p>
+
+<p>You have received new {type} feedback for your post.</p>
+
+<p><strong>Post:</strong> <a href="{post_url}">{post_title}</a><br>
+<strong>Name:</strong> {name}<br>
+<strong>Email:</strong> {email}<br>
+<strong>Message:</strong> {message}</p>
+
+<p>This message was sent by {blog_name}.</p>

--- a/templates/tabs/tab-system.php
+++ b/templates/tabs/tab-system.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Helpful
- * @version 4.5.0
+ * @version 4.5.6
  * @since 1.0.0
  */
 use Helpful\Core\Helper;
@@ -84,13 +84,13 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label class="helpful-block" for="helpful_timezone"><?php _ex('Custom timezone', 'option name', 'helpful'); ?></label>
-				<?php $value = $options->get_option('helpful_timezone', date_default_timezone_get(), 'esc_attr'); ?>
+				<?php $value = $options->get_option('helpful_timezone', '', 'esc_attr'); ?>
 				<input type="text" class="regular-text code" name="helpful_timezone" value="<?php echo esc_attr($value); ?>">
 			</div><!-- .helpful-admin-group -->
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_multiple', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_multiple', 'off', 'on_off'); ?>
 					<input id="helpful_multiple" type="checkbox" name="helpful_multiple" <?php checked('on', $value); ?> />
 					<?php _ex('Enable to allow users to vote more than once in individual posts', 'label', 'helpful'); ?>
 				</label>
@@ -98,7 +98,7 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_notes', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_notes', 'off', 'on_off'); ?>
 					<input id="helpful_notes" type="checkbox" name="helpful_notes" <?php checked('on', $value); ?> />
 					<?php _ex('Check to completely disable admin notes for Helpful', 'label', 'helpful'); ?>
 				</label>
@@ -106,7 +106,7 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_plugin_first', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_plugin_first', 'off', 'on_off'); ?>
 					<input id="helpful_plugin_first" type="checkbox" name="helpful_plugin_first" <?php checked('on', $value); ?> />
 					<?php _ex('Select so that Helpful is always loaded first', 'label', 'helpful'); ?>
 				</label>
@@ -114,7 +114,7 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_classic_editor', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_classic_editor', 'off', 'on_off'); ?>
 					<input id="helpful_classic_editor" type="checkbox" name="helpful_classic_editor" <?php checked('on', $value); ?> />
 					<?php _ex('Activate the classic editor and deactivate the block editor', 'label', 'helpful'); ?>
 				</label>
@@ -122,7 +122,7 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_classic_widgets', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_classic_widgets', 'off', 'on_off'); ?>
 					<input id="helpful_classic_widgets" type="checkbox" name="helpful_classic_widgets" <?php checked('on', $value); ?> />
 					<?php _ex('Activate the classic widgets and deactivate the block editor for widgets', 'label', 'helpful'); ?>
 				</label>
@@ -130,17 +130,25 @@ do_action('helpful_tab_system_before');
 
 			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_disable_frontend_nonce', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_disable_frontend_nonce', 'off', 'on_off'); ?>
 					<input id="helpful_disable_frontend_nonce" type="checkbox" name="helpful_disable_frontend_nonce" <?php checked('on', $value); ?> />
 					<?php _ex('Disable frontend nonce (not recommended)', 'label', 'helpful'); ?>
 				</label>
 			</div><!-- .helpful-admin-group -->
 
-			<div class="helpful-admin-group">
+			<div class="helpful-admin-group helpful-margin-bottom">
 				<label>
-					<?php $value = $options->get_option('helpful_disable_feedback_nonce', 'off', 'esc_attr'); ?>
+					<?php $value = $options->get_option('helpful_disable_feedback_nonce', 'off', 'on_off'); ?>
 					<input id="helpful_disable_feedback_nonce" type="checkbox" name="helpful_disable_feedback_nonce" <?php checked('on', $value); ?> />
 					<?php _ex('Disable feedback nonce (not recommended)', 'label', 'helpful'); ?>
+				</label>
+			</div><!-- .helpful-admin-group -->
+
+			<div class="helpful-admin-group">
+				<label>
+					<?php $value = $options->get_option('helpful_log_mailer_errors', 'off', 'on_off'); ?>
+					<input id="helpful_log_mailer_errors" type="checkbox" name="helpful_log_mailer_errors" <?php checked('on', $value); ?> />
+					<?php _ex('Save error messages when sending emails in the error log.', 'label', 'helpful'); ?>
 				</label>
 			</div><!-- .helpful-admin-group -->
 		</div><!-- .helpful-admin-panel-content -->


### PR DESCRIPTION
**Enhanced**

* There are now options under System to disable it Block Editor for widgets and the option that wp_mail errors are saved in the error log.
* The template for the emails is now no longer used with file_get_contents. Instead wp_remote_get is used. This can fix errors. A better alternative is welcome.