### PR TITLE
4.5.7

### DIFF
--- a/core/helpers/class-feedback.php
+++ b/core/helpers/class-feedback.php
@@ -2,7 +2,7 @@
 /**
  * @package Helpful
  * @subpackage Core\Helpers
- * @version 4.4.63
+ * @version 4.5.7
  * @since 1.0.0
  */
 namespace Helpful\Core\Helpers;
@@ -624,35 +624,57 @@ class Feedback
     /**
      * Get feedback email content.
      *
-     * @version 4.5.6
+     * @version 4.5.7
      * 
      * @return string
      */
     public static function get_email_content()
     {
-        $file = plugins_url('templates/emails/feedback-email.txt', HELPFUL_FILE);
-        $file = apply_filters('helpful_pre_get_email_content_voter_file', $file);
+        $file = HELPFUL_PATH . '/templates/emails/feedback-email.txt';
+        $file = apply_filters('helpful/emails/pre_feedback_email_file', $file);
 
-        $response = wp_remote_get($file);
-        $response = wp_remote_retrieve_body($response);
+        if (!file_exists($file)) {
+            return '';
+        }
 
-        return apply_filters('helpful_pre_get_email_content_voter', $response);
+        $response = wp_cache_get('helpful/templates/emails/feedback_email');
+
+        if (false === $response) {
+            ob_start();
+            include $file;
+            $response = ob_get_contents();
+            ob_end_clean();
+            wp_cache_set('helpful/templates/emails/feedback_email', $response);
+        }
+
+        return apply_filters('helpful_pre_get_email_content', $response);
     }
 
     /**
      * Get feedback email content for voters.
      *
-     * @version 4.5.6
+     * @version 4.5.7
      * 
      * @return string
      */
     public static function get_email_content_voter()
     {
-        $file = plugins_url('templates/emails/feedback-email-voter.txt', HELPFUL_FILE);
-        $file = apply_filters('helpful_pre_get_email_content_voter_file', $file);
+        $file = HELPFUL_PATH . '/templates/emails/feedback-email-voter.txt';
+        $file = apply_filters('helpful/emails/pre_feedback_email_voter_file', $file);
 
-        $response = wp_remote_get($file);
-        $response = wp_remote_retrieve_body($response);
+        if (!file_exists($file)) {
+            return '';
+        }
+
+        $response = wp_cache_get('helpful/templates/emails/feedback_voter_email');
+
+        if (false === $response) {
+            ob_start();
+            include $file;
+            $response = ob_get_contents();
+            ob_end_clean();
+            wp_cache_set('helpful/templates/emails/feedback_voter_email', $response);
+        }
 
         return apply_filters('helpful_pre_get_email_content_voter', $response);
     }

--- a/core/modules/class-core.php
+++ b/core/modules/class-core.php
@@ -2,7 +2,7 @@
 /**
  * @package Helpful
  * @subpackage Core\Modules
- * @version 4.5.0
+ * @version 4.5.7
  * @since 4.3.0
  */
 namespace Helpful\Core\Modules;
@@ -56,8 +56,6 @@ class Core
         add_action('upgrader_process_complete', [ & $this, 'on_plugin_update'], 10, 2);
 
         add_action('wp_mail_failed', [ & $this, 'log_mailer_errors'], 10, 1);
-
-        add_filter('use_widgets_block_editor', [ & $this, 'disable_widgets_block_editor'], 10, 1);
     }
 
     /**
@@ -387,23 +385,5 @@ class Core
 
         $message = 'Helpful Error: ' . $wp_error->get_error_message();
         helpful_error_log($message);
-    }
-
-    /**
-     * @version 4.5.6
-     * 
-     * @param bool $current_status
-     * 
-     * @return bool
-     */
-    public function disable_widgets_block_editor($current_status)
-    {
-        $options = new Services\Options();
-    
-        if ('off' === $options->get_option('helpful_log_mailer_errors', 'off', 'on_off')) {
-            return $current_status;
-        }
-
-        return false;
     }
 }

--- a/core/tabs/class-system.php
+++ b/core/tabs/class-system.php
@@ -2,7 +2,7 @@
 /**
  * @package Helpful
  * @subpackage Core\Tabs
- * @version 4.5.6
+ * @version 4.5.7
  * @since 4.3.0
  */
 namespace Helpful\Core\Tabs;
@@ -41,7 +41,7 @@ class System
     /**
      * Class constructor
      *
-     * @version 4.4.59
+     * @version 4.5.7
      *
      * @return void
      */
@@ -57,8 +57,12 @@ class System
         add_action('admin_init', [ & $this, 'reset_plugin']);
         add_action('admin_init', [ & $this, 'reset_feedback']);
 
-        if ('on' === $options->get_option('helpful_classic_editor', 'off', 'esc_attr')) {
+        if ('on' === $options->get_option('helpful_classic_editor', 'off', 'on_off')) {
             add_filter('use_block_editor_for_post', '__return_false', 10);
+        }
+
+        if ('on' === $options->get_option('helpful_classic_widgets', 'off', 'on_off')) {
+            add_filter('use_widgets_block_editor', '__return_false', 10);
         }
 
         add_action('helpful_tab_system_before', [ & $this, 'register_tab_alerts']);

--- a/helpful.php
+++ b/helpful.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Helpful
  * Description: Add a fancy feedback form under your posts or post-types and ask your visitors a question. Give them the abbility to vote with yes or no.
- * Version: 4.5.6
+ * Version: 4.5.7
  * Author: Pixelbart
  * Author URI: https://pixelbart.de
  * Text Domain: helpful

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: helpful, poll, feedback, reviews, vote, review, voting
 Requires at least: 4.6
 Tested up to: 5.9
 Requires PHP: 5.6.20
-Stable tag: 4.5.6
+Stable tag: 4.5.7
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
**Fixed**

* Now ob_start is used again for the feedback emails. So that there are fewer problems, the content of the file is stored in the object cache so that it is retrieved only once per pageload.
* The option to disable the new block editor widgets now works as intended.