### PR TITLE
Fix `update_option` logic for "Reset Helpful" & "Reset Feedback" options

### DIFF
--- a/core/tabs/class-system.php
+++ b/core/tabs/class-system.php
@@ -204,7 +204,7 @@ class System {
 
 		$wpdb->query( "TRUNCATE TABLE $table_name" );
 
-		update_option( 'helpful_uninstall', false );
+		$options->update_option( 'helpful_uninstall', 'off' );
 
 		$args = array(
 			'post_type'      => 'any',
@@ -248,7 +248,7 @@ class System {
 
 		$wpdb->query( "TRUNCATE TABLE $table_name" );
 
-		update_option( 'helpful_uninstall_feedback', false );
+		$options->update_option( 'helpful_uninstall_feedback', 'off' );
 	}
 
 	/**


### PR DESCRIPTION
When checking the **Reset Helpful** or **Reset Feedback** options in the **System** tab of the plugin settings and then saving the changes, these checkboxes are not restored to their unchecked state. A user will assume that checking one of these checkboxes only runs the reset once, while in reality since the checkbox remains checked, any submitted feedback _will get automatically deleted_ shortly after it has been submitted (on admin page reload it seems).

The checkboxes are not restored to the unchecked state because the WP [`update_option`](https://core.trac.wordpress.org/browser/tags/5.9.3/src/wp-includes/option.php#L77) function (which I believe is unintentionally being used by your plugin here) does not accept `false` as the value for an option, or more correctly it checks if the value is `empty()` and if it is (`false` counts as empty here) the function returns early without actually updating the option.

I'm guessing that since you are instantiating your `Services\Options` class in the `$options` variable in the beginning of the two functions which handle these resets, you were intending to use the `update_option` method inside _that_ class, rather than the WP `update_option` function? With the changes in this PR, the checkboxes are reset to their unchecked state as expected after saving the settings with either option checked.

Presumably `update_option('helpful_is_installed', 0)` [on line 232](https://github.com/pixelbart/helpful/blob/master/core/tabs/class-system.php#L232) should also rather be `$options->update_option('helpful_is_installed', 0)` since the value `0` will also be recognized as empty by WP's `update_option`? 

That being said, you do also have logic in your own [`update_option` method in `Services\Options`](https://github.com/pixelbart/helpful/blob/master/core/services/class-options.php#L54-L56) which returns early without making any changes if the value is not a string...